### PR TITLE
refactor(home): separate home data logic into useHomeBusinesses hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,336 @@
+# Local Guides / Resto Finder App
+
+A React Native + Expo application for discovering nearby restaurants, cafes, and fast food spots, with business data from **Geoapify** and user-generated reviews and analytics stored in **Firebase**.
+
+The app features:
+
+- Authenticated users (email/password) with roles (`user` / `admin`).
+- A home screen that surfaces nearby places, top-rated spots, and trending businesses.
+- Business details with hours, reviews, and helpful-vote functionality.
+- Favorites and profile screens.
+- An admin dashboard for high-level analytics.
+
+This README focuses on **setup**, **architecture/structure**, **API integration**, and **testing**, to address the mentor feedback on documentation and project design.
+
+---
+
+## 1. Getting Started
+
+### 1.1 Prerequisites
+
+- Node.js and npm (LTS recommended)
+- Expo tooling (`npx expo` will be installed on the fly)
+- iOS simulator (Xcode) and/or Android emulator/physical device
+
+### 1.2 Install dependencies
+
+From the project root:
+
+```bash
+npm install
+```
+
+### 1.3 Environment configuration
+
+Secrets and API keys are configured via `.env` and consumed in `app.config.js` / `expo-constants`.
+
+You should have a `.env` file with entries similar to:
+
+```bash
+# Firebase
+FIREBASE_API_KEY=...
+FIREBASE_AUTH_DOMAIN=...
+FIREBASE_PROJECT_ID=...
+FIREBASE_STORAGE_BUCKET=...
+FIREBASE_MESSAGING_SENDER_ID=...
+FIREBASE_APP_ID=...
+
+# Geoapify
+GEOAPIFY_API_KEY=...
+```
+
+These are read in `app.config.js` and exposed via `Constants.expoConfig?.extra` so services like `geoapifyService` and Firebase clients can access them.
+
+> Do not commit real credentials. Use a separate `.env.example` file when sharing the project.
+
+### 1.4 Running the app
+
+```bash
+# iOS simulator
+npm run ios
+
+# Android emulator / device
+npm run android
+
+# Metro / dev server
+npm start
+```
+
+Expo will take care of bundling and launching the app on the chosen platform.
+
+---
+
+## 2. Project Structure & Architecture
+
+All application code lives under `src/`, grouped by responsibility:
+
+```text
+src/
+  assets/         # App-specific static assets (images, icons, etc.)
+  components/     # Reusable presentational components
+  config/         # App config helpers
+  constants/      # UI + domain constants (e.g. categories, colors)
+  context/        # React context providers (Auth, etc.)
+  hooks/          # App-specific hooks (stateful + data/hooks)
+  navigation/     # Navigation stacks and tab navigators
+  screens/        # Screen-level components (pages)
+  services/       # Business/domain logic and API integration
+  types/          # Shared TypeScript types
+  utils/          # Pure utility functions (e.g. mappers)
+```
+
+### 2.1 Screens
+
+`src/screens/*` contains the main app screens. Examples:
+
+- `src/screens/home/index.tsx` – Home screen showing:
+  - Welcome header (based on `AuthContext` / profile name).
+  - Search bar (navigates to Explore).
+  - Category filter.
+  - Top Rated and Popular Nearby horizontal carousels.
+  - Main list of nearby places (driven by React Query + Geoapify + review stats).
+- `src/screens/entry/SignUpScreen.tsx` – Email/password signup flow using `useAuthContext().signup`.
+- `src/screens/favorites/favorites.tsx` – User’s favorites list using favorites hooks.
+- `src/screens/admin/AdminDashboardScreen.tsx` – Admin-only analytics view.
+
+Screens are primarily responsible for **layout and composition**:
+
+- They connect to hooks and context (`useAuthContext`, query hooks, etc.).
+- They render reusable components (`BusinessCard`, `CategoryFilter`, `ReviewCard`, etc.).
+- They handle navigation via `@react-navigation/native`.
+
+### 2.2 Components
+
+`src/components/*` contains reusable UI pieces that are mostly stateless or lightly stateful:
+
+- `BusinessCard.tsx` – Compact card for a business (image, name, rating, etc.).
+- `CategoryFilter.tsx` – Horizontal filters for "All", "Restaurants", "Cafes", etc.
+- `StarRating.tsx` – Visual star rating display.
+- `ReviewCard.tsx` – Presentation for a single review.
+- `StyledInput.tsx`, `FormContainer.tsx`, `KeyboardAvoidingScrollView.tsx` – Auth/form helpers.
+- `findingPlacesLoader.tsx` – Loading skeleton/animation for searching places.
+
+These components receive data and callbacks as props and do not perform network calls.
+
+### 2.3 Hooks
+
+`src/hooks/*` contains application-specific hooks that encapsulate **stateful logic** and **business rules** used by multiple screens.
+
+Key examples:
+
+- `useAuth.ts` – Wraps Firebase Auth and Firestore user docs:
+  - Tracks `user`, `loading`, `error`, `userRole`, and `profileName`.
+  - Exposes `login`, `signup`, `logout`, and `resetPassword`.
+  - Stores FCM tokens in Firestore via `notificationService` and `updateUserFcmToken`.
+  - Used by `AuthContext` to provide auth state/app role across the app.
+- `useProtectedAction.ts` – Wraps actions with connectivity checks, used to guard network operations.
+- `useInternetConnectivity.ts` – Wraps NetInfo into a simple, testable hook for online/offline status.
+- `hooks/queries/useNearbyBusinessesQuery.ts` – React Query hooks over `businessService`:
+  - `useNearbyBusinessesQuery` – single-page nearby fetch with caching.
+  - `useInfiniteNearbyBusinessesQuery` – infinite scroll over Geoapify places.
+  - `useRefreshNearbyBusinesses` – explicit refresh that bypasses AsyncStorage cache.
+- `useHomeBusinesses.ts` – Feature hook that composes connectivity, location, infinite nearby businesses, and client-side filtering (category + search) into a single, reusable data facade for `HomeScreen`.
+- `useLocation.ts` – Encapsulates reading and refreshing the user’s location.
+
+These hooks form the middle “service-to-UI” layer that keeps screens thinner.
+
+### 2.4 Services (Business/Domain Layer)
+
+`src/services/*` handles external APIs and business/aggregation logic.
+
+- `businessService.ts`
+  - Orchestrates business discovery:
+    - Calls `geoapifyService.searchNearbyPlaces` with mapped categories.
+    - Aggregates review stats with `reviewService.getBusinessesWithReviews`.
+    - Maps raw Geoapify places to internal `Business` models using `mapGeoapifyToBusiness`.
+  - Implements cross-session caching in AsyncStorage (cache key + TTL) for nearby searches.
+  - Provides paginated `getNearbyBusinessesPage` for infinite scroll.
+  - Upserts canonical `businesses` documents in Firestore for analytics.
+
+- `geoapifyService.ts`
+  - Wraps the Geoapify Places API:
+    - `searchNearbyPlaces` – places near a lat/lon with category filters and radius.
+    - `getPlaceDetails` – single place details by `place_id`.
+    - `searchPlacesByName` – name-based search endpoint.
+  - Handles:
+    - URL building (categories, filters, offsets/limits).
+    - Response transformation into `GeoapifyPlace` objects (coordinates, address, cuisine/brand, etc.).
+    - In-memory caching and pending-request deduplication.
+
+- `reviewService.ts`
+  - Handles review CRUD and aggregation:
+    - `addReview`, `updateReview`, `deleteReview`.
+    - `getReviewsForBusiness`, `getUserReviews`.
+    - `getBusinessesWithReviews` – aggregates average rating + count per business.
+    - Helpful votes: `addHelpfulVote`, `removeHelpfulVote`, `hasUserVoted`, `updateReviewHelpfulCount`.
+  - Integrates with `imageService` to delete review images from Storage upon review deletion.
+
+- `imageService.ts`
+  - Uploads and deletes images to/from Firebase Storage:
+    - `uploadImage` – takes base64 data, builds a user- and type-specific path, uploads, returns a download URL.
+    - `deleteImage` – deletes a single image (with auth guard).
+    - `deleteImages` – utility to delete multiple images resiliently.
+
+- `notificationService.ts`
+  - Manages Notifee + FCM tokens:
+    - `requestPermissionAndGetToken` – debounced permission/token request with secure storage.
+    - `clearCachedToken`, `getCurrentToken`.
+    - Foreground/background handlers for notification events.
+
+- `secureStorage.ts`
+  - Wraps `react-native-encrypted-storage` with typed helpers for storing/retrieving/removing secure config and tokens.
+
+These services deliberately avoid UI concerns, making them easier to test and reason about.
+
+### 2.5 Context
+
+`src/context/AuthContext.tsx` provides a single `AuthProvider` and `useAuthContext` hook:
+
+- Wraps `useAuth()` and surfaces:
+  - `user`, `loading`, `error`.
+  - `login`, `signup`, `logout`, `resetPassword`.
+  - `role`, `isAdmin`, `profileName`.
+- All screens that need auth information or role checks use `useAuthContext()` instead of talking to Firebase directly.
+
+### 2.6 Utils
+
+`src/utils/*` contains small, focused helpers:
+
+- `businessMapper.ts` – `mapGeoapifyToBusiness` converts raw `GeoapifyPlace` + review stats into your `Business` domain type:
+  - Picks a category (restaurant/cafe/fast_food) based on Geoapify categories.
+  - Estimates price level.
+  - Builds placeholder images and opening hours if not provided.
+  - Derives features from cuisines, brands, and categories.
+
+These helpers are pure functions and are heavily unit-tested.
+
+---
+
+## 3. API Integration Overview
+
+### 3.1 Firebase
+
+The app uses React Native Firebase modules:
+
+- `@react-native-firebase/app` – base config (initialized via Expo runtime).
+- `@react-native-firebase/auth` – email/password auth.
+- `@react-native-firebase/firestore` – user profiles, reviews, helpful votes, and canonical business docs.
+- `@react-native-firebase/storage` – profile/review images.
+- `@react-native-firebase/messaging` – FCM tokens for notifications.
+- `@notifee/react-native` – local and push notification handling.
+
+Key integration points:
+
+- `hooks/useAuth.ts`
+  - Uses `getAuth`, `onAuthStateChanged`, `signInWithEmailAndPassword`, `createUserWithEmailAndPassword`, `signOut`, `updateProfile`.
+  - Uses Firestore (`getFirestore`, `doc`, `getDoc`, `setDoc`, `updateDoc`, `serverTimestamp`) for user profiles and roles.
+- `services/reviewService.ts`
+  - Uses Firestore collections (`reviews`, `helpfuls`) for review data and helpful votes.
+- `services/imageService.ts`
+  - Uses Storage (`getStorage`, `ref`, `uploadString`, `getDownloadURL`, `deleteObject`) for images.
+- `services/notificationService.ts`
+  - Uses Messaging (`messaging().requestPermission()`, `messaging().getToken()`) and Notifee for displaying notifications and handling events.
+
+### 3.2 Geoapify
+
+- Configuration:
+  - `GEOAPIFY_API_KEY` from `.env` → `Constants.expoConfig?.extra.GEOAPIFY_API_KEY`.
+- `services/geoapifyService.ts`:
+  - Constructs URLs like:
+
+    ```text
+    https://api.geoapify.com/v2/places?categories=...&filter=circle:lon,lat,radius&limit=...&offset=...&apiKey=GEOAPIFY_API_KEY
+    ```
+
+  - Transforms `features` into internal `GeoapifyPlace` objects, making sure lat/lon, categories, and address fields are consistent.
+- `services/businessService.ts`:
+  - Maps app categories (restaurants/cafes/fast_food) to Geoapify category strings.
+  - Delegates raw fetching to `geoapifyService` and focuses on mapping and caching.
+
+---
+
+## 4. Testing Strategy
+
+The test suite uses **Jest** and **@testing-library/react-native** for unit and integration tests, plus **Maestro** for a small end-to-end smoke test.
+
+### 4.1 Unit & Integration Tests (Jest)
+
+Configuration:
+
+- `jest.config.js`:
+  - `preset: 'react-native'`
+  - `testEnvironment: 'jsdom'`
+  - `setupFilesAfterEnv: ['<rootDir>/jest.setup.js']`
+  - Path alias resolution for `@/src/*`.
+- `jest.setup.js`:
+  - Mocks heavy native/external modules so tests don’t require a device:
+    - AsyncStorage, Firebase (app/auth/firestore/messaging/storage), Notifee.
+    - `react-native-encrypted-storage`, `@react-native-community/netinfo`, `@react-native-community/geolocation`.
+    - `react-native-chart-kit` replaced with lightweight `<View>` components.
+
+Highlights:
+
+- **Services**
+  - `__tests__/services/businessService.test.ts` – caching behavior and integration with Geoapify + AsyncStorage.
+  - `__tests__/services/secureStorage.test.ts` – serialization, deserialization, and clear/remove semantics.
+  - `__tests__/services/notificationService.test.ts` – FCM token permission, caching, and secure storage.
+  - `__tests__/services/geoapifyService.test.ts` – URL building, response transform, caching, and error fallback.
+  - `__tests__/services/reviewService.test.ts` – mapping Firestore snapshots into `Review` objects, deleting review images.
+  - `__tests__/services/imageService.test.ts` – upload/delete flows with Storage and auth guards.
+
+- **Hooks**
+  - `__tests__/hooks/useProtectedAction.test.ts` – behavior when online vs offline and guarding actions.
+
+- **Screens (integration)**
+  - `__tests__/screens/HomeScreen.test.tsx` – renders HomeScreen underneath Navigation + Auth + React Query providers; mocks data hooks and BusinessCard to ensure the "Test Cafe" business appears.
+  - `__tests__/screens/BusinessDetailsScreen.test.tsx` – checks that a business and at least one review render with mocked queries.
+  - `__tests__/screens/FavoritesScreen.test.tsx` – verifies favorites list and unfavorite interaction.
+
+For more detail, see `TESTING.md`.
+
+### 4.2 End-to-end (E2E) Tests (Maestro)
+
+Maestro flows live under `maestro/`:
+
+- `maestro/home_smoke.yaml` –
+  - Launches the app.
+  - Asserts the Home subtitle and search placeholder are visible.
+  - Optionally taps on the search bar.
+  - Does **not** clear app state (assumes user already signed in on device).
+
+- `maestro/login_and_home.yaml` –
+  - Clears app state.
+  - Launches the app and drives the login screen:
+    - Taps the email/password fields.
+    - Inputs `MAESTRO_EMAIL` / `MAESTRO_PASSWORD` from env vars.
+    - Taps the sign-in button.
+  - Asserts the Home screen subtitle and search placeholder are visible.
+
+To run these flows, install Maestro CLI and follow the instructions in `TESTING.md`.
+
+---
+
+## 5. Summary
+
+This project’s architecture separates concerns into:
+
+- **Screens** for UI and navigation.
+- **Components** for reusable presentation.
+- **Hooks** for app-specific state and orchestration.
+- **Services** for business logic and external integrations.
+- **Context** for shared app state (auth, role, profile).
+- **Utils** for pure helpers (like mapping external API data to domain models).
+
+Testing covers core services, hooks, and screens via Jest, with a minimal Maestro-based e2e flow to validate the real app on a device.
+
+This structure and documentation are designed to make the app easier to understand, extend, and evaluate from an architectural and production-readiness perspective.

--- a/src/hooks/useHomeBusinesses.ts
+++ b/src/hooks/useHomeBusinesses.ts
@@ -1,0 +1,175 @@
+import { useState, useMemo, useEffect, useCallback } from "react";
+import { useInfiniteNearbyBusinessesQuery } from "@/src/hooks/queries/useNearbyBusinessesQuery";
+import { useInternetConnectivity } from "@/src/hooks/useInternetConnectivity";
+import { useLocation } from "@/src/hooks/useLocation";
+import { useQueryClient } from "@tanstack/react-query";
+import { businessQueryKeys } from "@/src/services/businessService";
+import { Business } from "@/src/types";
+
+export interface UseHomeBusinessesArgs {
+  selectedCategory: string;
+  searchQuery: string;
+}
+
+export function useHomeBusinesses({
+  selectedCategory,
+  searchQuery,
+}: UseHomeBusinessesArgs) {
+  const { isConnected, showOfflineAlert } = useInternetConnectivity();
+  const { userLocation } = useLocation();
+  const queryClient = useQueryClient();
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    dataUpdatedAt,
+  } = useInfiniteNearbyBusinessesQuery();
+
+  const businesses = useMemo(
+    () => (data?.pages ?? []).flat() as Business[],
+    [data?.pages]
+  );
+
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (!hasLoadedOnce && userLocation && !isLoading && !isFetching) {
+      setHasLoadedOnce(true);
+    }
+  }, [hasLoadedOnce, userLocation, isLoading, isFetching]);
+
+  const isInitialLoading =
+    !userLocation ||
+    (!hasLoadedOnce && ((isLoading || isFetching) || businesses.length === 0)) ||
+    ((isLoading || isFetching) && businesses.length === 0);
+
+  const showEmptyState =
+    hasLoadedOnce &&
+    !!userLocation &&
+    !isLoading &&
+    !isFetching &&
+    !refreshing &&
+    businesses.length === 0;
+
+  const hasContent = businesses.length > 0;
+
+  const filteredBusinesses = useMemo(() => {
+    let result = businesses;
+
+    if (selectedCategory !== "all") {
+      result = result.filter(
+        (business) => business.category === selectedCategory
+      );
+    }
+
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (b) =>
+          b.name.toLowerCase().includes(q) ||
+          b.address.toLowerCase().includes(q) ||
+          b.features.some((f) => f.toLowerCase().includes(q))
+      );
+    }
+
+    return result;
+  }, [businesses, searchQuery, selectedCategory]);
+
+  const topRatedBusinesses = useMemo(() => {
+    return filteredBusinesses
+      .filter((b) => b.rating >= 4.0)
+      .sort((a, b) => b.rating - a.rating)
+      .slice(0, 3);
+  }, [filteredBusinesses]);
+
+  const trendingBusinesses = useMemo(() => {
+    return filteredBusinesses
+      .slice()
+      .sort((a, b) => b.reviewCount - a.reviewCount)
+      .slice(0, 3);
+  }, [filteredBusinesses]);
+
+  const cacheUpdatedLabel = useMemo(() => {
+    if (!dataUpdatedAt) return null;
+    const ageMs = Date.now() - dataUpdatedAt;
+
+    if (ageMs < 60 * 1000) return "Updated just now";
+
+    const minutes = Math.floor(ageMs / (60 * 1000));
+    if (minutes < 60) return `Updated ${minutes} min ago`;
+
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+      return `Updated ${hours} hr${hours > 1 ? "s" : ""} ago`;
+    }
+
+    return "Updated over 1 day ago";
+  }, [dataUpdatedAt]);
+
+  const handleRefresh = useCallback(async () => {
+    if (!isConnected) {
+      showOfflineAlert();
+      return;
+    }
+
+    if (!userLocation) {
+      console.log("⚠️ Cannot refresh: user location not available yet");
+      return;
+    }
+
+    setRefreshing(true);
+    try {
+      const infiniteKey = [
+        ...businessQueryKeys.lists(),
+        "infinite",
+        {
+          lat: userLocation.latitude,
+          lng: userLocation.longitude,
+          radius: 5000,
+          categories: [],
+        },
+      ];
+
+      queryClient.removeQueries({ queryKey: infiniteKey });
+      await refetch();
+    } catch (error) {
+      console.error("Refresh failed:", error);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [
+    refetch,
+    isConnected,
+    showOfflineAlert,
+    queryClient,
+    userLocation,
+  ]);
+
+  const handleLoadMore = useCallback(() => {
+    if (!hasNextPage || isFetchingNextPage) return;
+    fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return {
+    businesses,
+    filteredBusinesses,
+    topRatedBusinesses,
+    trendingBusinesses,
+    cacheUpdatedLabel,
+    isInitialLoading,
+    showEmptyState,
+    hasContent,
+    refreshing,
+    isConnected,
+    handleRefresh,
+    handleLoadMore,
+    hasNextPage,
+    isFetchingNextPage,
+  };
+}


### PR DESCRIPTION
- Introduce useHomeBusinesses to encapsulate React Query, Geoapify, connectivity, and filtering logic for the Home experience
- Update HomeScreen to focus on presentation and navigation, consuming home data exclusively via useHomeBusinesses
- Document the new hook and layering in README.md to clarify the architecture and separation of concerns