### PR TITLE
docs: clarify state management and service layer architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,34 @@ These helpers are pure functions and are heavily unit-tested.
 
 ---
 
-## 3. API Integration Overview
+## 3. State Management
+
+The app uses a combination of **React Query**, **custom hooks/contexts**, and a small client-side store to manage state.
+
+- **Server state (remote data):**
+  - React Query hooks (e.g. `useNearbyBusinessesQuery`, `useInfiniteNearbyBusinessesQuery`, `useBusinessDetailsQuery`, `useBusinessReviewsQuery`) fetch and cache data from Geoapify and Firebase.
+  - These hooks always talk to the API via services (`businessService`, `geoapifyService`, `reviewService`, etc.) so that network logic is not embedded in screens.
+- **Client state (UI + derived state):**
+  - `AuthContext` + `useAuth` manage the authenticated user, role (`user` / `admin`), and profile name.
+  - `useHomeBusinesses` is a feature hook for Home that composes:
+    - Connectivity (`useInternetConnectivity`),
+    - Location (`useLocation`),
+    - Infinite nearby businesses (`useInfiniteNearbyBusinessesQuery`), and
+    - Client-side filters (category + search),
+    into a single stateful façade consumed by `HomeScreen`.
+  - `useAppStore` acts as a thin orchestration layer for cross-screen client state such as:
+    - Locally cached businesses, reviews, and favorites,
+    - Search and refresh helpers,
+    while delegating all remote data access to `businessService`, `reviewService`, and `favoriteService` via `useProtectedAction`.
+  - `useUserFavorites` is a tiny hook that exposes the current user’s favorite IDs from `useAppStore`, giving consumers a clear entry point for favorites state.
+- **Network/side-effect guard:**
+  - `useProtectedAction` centralizes connectivity checks and retry/alert behavior around async actions, so services and hooks can assume they are called only when the device is online.
+
+This separation makes it clear what is **server state** (owned by React Query + services) vs what is **client/derived state** (owned by hooks/contexts like `useHomeBusinesses`, `useAppStore`, and `AuthContext`).
+
+---
+
+## 4. API Integration Overview
 
 ### 3.1 Firebase
 
@@ -259,7 +286,7 @@ Key integration points:
 
 ---
 
-## 4. Testing Strategy
+## 5. Testing Strategy
 
 The test suite uses **Jest** and **@testing-library/react-native** for unit and integration tests, plus **Maestro** for a small end-to-end smoke test.
 
@@ -320,7 +347,7 @@ To run these flows, install Maestro CLI and follow the instructions in `TESTING.
 
 ---
 
-## 5. Summary
+## 6. Summary
 
 This project’s architecture separates concerns into:
 

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -5,7 +5,32 @@ import { favoriteService } from "@/src/services/favoriteService";
 import { useAuth } from "./useAuth";
 import { useLocation } from "./useLocation";
 import { Review, Business, SearchFilters } from "@/src/types";
-import { useProtectedAction } from '@/src/hooks/useProtectedAction';
+import { useProtectedAction } from "@/src/hooks/useProtectedAction";
+
+/**
+ * Global app store for **client-side** cross-cutting concerns.
+ *
+ * Responsibilities:
+ * - Hold in-memory copies of "local" state that is shared across multiple
+ *   screens (e.g. cached `businesses`, `reviews`, `favorites`, and
+ *   local search results).
+ * - Coordinate side effects such as:
+ *   - Subscribing to Firestore favorites via `favoriteService` once per
+ *     authenticated user.
+ *   - Orchestrating nearby-business loading by delegating to
+ *     `businessService` and `reviewService` through `useProtectedAction`.
+ * - Expose high-level helpers like `loadNearbyBusinesses`,
+ *   `refreshBusinesses`, `searchBusinesses`, `getBusinessById`, etc., so
+ *   UI components and feature hooks don't need to know about Firestore,
+ *   Geoapify, or connectivity details.
+ *
+ * It deliberately does **not** perform direct network calls itself; instead,
+ * all remote access goes through the dedicated services layer (`businessService`,
+ * `reviewService`, `favoriteService`, `notificationService`, etc.). This keeps
+ * server state and side effects encapsulated and makes it easier to evolve the
+ * state management strategy (e.g. moving more into React Query or Zustand)
+ * without rewriting UI components.
+ */
 
 // ✅ Global state for business loading coordination
 const globalState = {

--- a/src/hooks/useHomeBusinesses.ts
+++ b/src/hooks/useHomeBusinesses.ts
@@ -6,6 +6,25 @@ import { useQueryClient } from "@tanstack/react-query";
 import { businessQueryKeys } from "@/src/services/businessService";
 import { Business } from "@/src/types";
 
+/**
+ * Feature-level hook that encapsulates all **Home** data logic.
+ *
+ * Responsibilities:
+ * - Fetch nearby businesses via `useInfiniteNearbyBusinessesQuery` and
+ *   `businessService.getNearbyBusinessesPage`.
+ * - Combine server state with client concerns:
+ *   - Connectivity (`useInternetConnectivity`),
+ *   - Location (`useLocation`),
+ *   - Category + search filters (derived `filteredBusinesses`),
+ *   - Derived collections (`topRatedBusinesses`, `trendingBusinesses`).
+ * - Expose UI-friendly flags (`isInitialLoading`, `showEmptyState`,
+ *   `hasContent`, `refreshing`) and callbacks (`handleRefresh`,
+ *   `handleLoadMore`).
+ *
+ * This keeps `HomeScreen` focused on presentation and navigation while this
+ * hook owns all the stateful behavior required to power the screen.
+ */
+
 export interface UseHomeBusinessesArgs {
   selectedCategory: string;
   searchQuery: string;

--- a/src/hooks/useProtectedAction.ts
+++ b/src/hooks/useProtectedAction.ts
@@ -2,6 +2,20 @@ import { useCallback } from 'react';
 import { useInternetConnectivity } from './useInternetConnectivity';
 import { Alert } from 'react-native';
 
+/**
+ * Wraps async actions with connectivity checks and optional retry/alerts.
+ *
+ * - Calls `useInternetConnectivity().checkConnectivity()` before running
+ *   the provided action.
+ * - Presents a user-facing alert with optional "Retry" when offline.
+ * - Returns `false` instead of throwing when the action is blocked by
+ *   offline state, making it easy for callers to bail out gracefully.
+ *
+ * This hook sits between UI/feature hooks (e.g. `useHomeBusinesses`,
+ * `useAppStore`) and the services layer, so network guarding logic is
+ * defined once and reused consistently.
+ */
+
 export const useProtectedAction = () => {
   const { isConnected, checkConnectivity, showOfflineAlert } = useInternetConnectivity();
 

--- a/src/services/businessService.ts
+++ b/src/services/businessService.ts
@@ -13,6 +13,24 @@ import {
   serverTimestamp,
 } from "@react-native-firebase/firestore";
 
+/**
+ * businessService
+ *
+ * Orchestrates business discovery and persistence:
+ * - Maps high-level app categories (restaurants/cafes/fast_food) to
+ *   Geoapify category strings.
+ * - Calls `geoapifyService` to search for places and `reviewService` to
+ *   gather aggregated rating/review-count per business.
+ * - Converts raw Geoapify places into internal `Business` domain objects
+ *   via `mapGeoapifyToBusiness`.
+ * - Persists/reads a cross-session AsyncStorage cache for nearby results.
+ * - Upserts canonical business documents into Firestore for analytics and
+ *   admin/dashboard usage.
+ *
+ * This module never touches UI components directly; it is consumed by
+ * React Query hooks and feature hooks like `useHomeBusinesses`.
+ */
+
 const mapAppCategoriesToGeoapify = (categories: string[]): string[] => {
   if (categories.length === 0) {
     return ["catering.restaurant", "catering.cafe", "catering.fast_food"];

--- a/src/services/favoriteService.ts
+++ b/src/services/favoriteService.ts
@@ -12,6 +12,19 @@ import {
 // Get Firestore instance
 const db = getFirestore();
 
+/**
+ * favoriteService
+ *
+ * Thin Firestore wrapper around the `userFavorites` collection:
+ * - Stores an array of `favoriteBusinessIds` per user.
+ * - Exposes helpers to add/remove/toggle a business as a favorite.
+ * - Provides a realtime `subscribeToFavorites` API so hooks like
+ *   `useAppStore` can react to updates.
+ *
+ * This keeps favorites persistence concerns out of components and
+ * normalizes how favorite state is stored and retrieved.
+ */
+
 export const favoriteService = {
   // Get user's favorites
   async getUserFavorites(userId: string): Promise<string[]> {

--- a/src/services/reviewService.ts
+++ b/src/services/reviewService.ts
@@ -22,6 +22,24 @@ import { imageService } from "./imageService";
 
 const db = getFirestore();
 
+/**
+ * reviewService
+ *
+ * Encapsulates all Firestore access and domain logic for reviews and
+ * helpful votes:
+ * - `addReview`, `updateReview`, `deleteReview` work with the `reviews`
+ *   collection and ensure timestamps are managed consistently.
+ * - `getReviewsForBusiness`, `getUserReviews`, and `getBusinessesWithReviews`
+ *   provide both raw lists and aggregated rating/review-count data per
+ *   business.
+ * - Integrates with `imageService` to delete associated review images from
+ *   Storage when a review is removed.
+ *
+ * UI and hooks rely on this service instead of talking to Firestore
+ * collections directly, which keeps persistence concerns out of
+ * presentation code.
+ */
+
 export interface HelpfulVote {
   reviewId: string;
   reviewOwnerId: string;


### PR DESCRIPTION
- Add detailed State Management section to README describing server vs client state and how React Query, hooks, and services interact
- Document useHomeBusinesses as the feature-level home data hook
- Add high-level doc blocks to useAppStore, useProtectedAction, businessService, reviewService, and favoriteService to clarify their responsibilities in the architecture