### PR TITLE
feat(offline): add mutation queues, offline banners, and auto-refresh on reconnect

### DIFF
--- a/__tests__/services/offlineQueueService.test.ts
+++ b/__tests__/services/offlineQueueService.test.ts
@@ -1,0 +1,111 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { offlineQueueService } from '@/src/services/offlineQueueService';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+const STORAGE_KEY = 'offlineMutations_v1';
+
+describe('offlineQueueService', () => {
+  beforeEach(async () => {
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+    (AsyncStorage.getItem as jest.Mock).mockClear();
+    (AsyncStorage.removeItem as jest.Mock).mockClear();
+    await offlineQueueService.clear();
+  });
+
+  it('enqueues mutations and persists them to AsyncStorage', async () => {
+    await offlineQueueService.enqueue({
+      type: 'review:add',
+      id: 'm1',
+      payload: {
+        businessId: 'b1',
+        userId: 'u1',
+        userName: 'Test User',
+        userAvatar: '',
+        rating: 5,
+        text: 'Great place',
+        images: [],
+      },
+      createdAt: new Date().toISOString(),
+    });
+
+    const mutations = await offlineQueueService.getAll();
+    expect(mutations).toHaveLength(1);
+    expect(mutations[0]).toMatchObject({ id: 'm1', type: 'review:add' });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, expect.stringContaining('m1'));
+  });
+
+  it('honors MAX_MUTATIONS by trimming older entries', async () => {
+    // Enqueue more than the cap (50) and make sure only the newest remain
+    const total = 60;
+    for (let i = 0; i < total; i++) {
+      await offlineQueueService.enqueue({
+        type: 'review:helpful',
+        id: `m${i}`,
+        reviewId: 'r1',
+        reviewOwnerId: 'owner',
+        taggedBy: 'u1',
+        businessId: 'b1',
+        delta: 1,
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    const mutations = await offlineQueueService.getAll();
+    // Expect we kept only the newest 50
+    expect(mutations).toHaveLength(50);
+    expect(mutations[0].id).toBe('m10');
+    expect(mutations[mutations.length - 1].id).toBe('m59');
+  });
+
+  it('clear() removes all mutations', async () => {
+    await offlineQueueService.enqueue({
+      type: 'review:delete',
+      id: 'delete-1',
+      reviewId: 'r1',
+      businessId: 'b1',
+      createdAt: new Date().toISOString(),
+    });
+
+    let mutations = await offlineQueueService.getAll();
+    expect(mutations).toHaveLength(1);
+
+    await offlineQueueService.clear();
+    mutations = await offlineQueueService.getAll();
+    expect(mutations).toHaveLength(0);
+  });
+
+  it('replaceAll() overwrites the stored mutations', async () => {
+    await offlineQueueService.enqueue({
+      type: 'review:add',
+      id: 'old',
+      payload: {
+        businessId: 'b1',
+        userId: 'u1',
+        userName: 'Test User',
+        userAvatar: '',
+        rating: 5,
+        text: 'Old review',
+        images: [],
+      },
+      createdAt: new Date().toISOString(),
+    });
+
+    await offlineQueueService.replaceAll([
+      {
+        type: 'review:delete',
+        id: 'new',
+        reviewId: 'r2',
+        businessId: 'b2',
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    const mutations = await offlineQueueService.getAll();
+    expect(mutations).toHaveLength(1);
+    expect(mutations[0]).toMatchObject({ id: 'new', type: 'review:delete' });
+  });
+});

--- a/src/components/BusinessCard.tsx
+++ b/src/components/BusinessCard.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Image, Pressable } from 'react-native';
 import { Heart, MapPin } from 'lucide-react-native';
 import Animated, {
   Easing,
@@ -7,11 +7,6 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
-import {
-  TapGestureHandler,
-  State as GestureState,
-  TapGestureHandlerStateChangeEvent,
-} from 'react-native-gesture-handler';
 import { Business } from '../types';
 import { useAppStore } from '../hooks/useAppStore';
 import StarRating from './StarRating';
@@ -44,37 +39,6 @@ const BusinessCard = memo(({ business, onPress, customHeartAction }: BusinessCar
     };
   });
 
-  const handleStateChange = (event: TapGestureHandlerStateChangeEvent) => {
-    const { state } = event.nativeEvent;
-
-    if (state === GestureState.BEGAN) {
-      // Press in: subtle shrink + dim overlay
-      pressed.value = 1;
-      scale.value = withTiming(0.98, {
-        duration: 90,
-        easing: Easing.out(Easing.ease),
-      });
-    }
-
-    if (
-      state === GestureState.END ||
-      state === GestureState.CANCELLED ||
-      state === GestureState.FAILED
-    ) {
-      // Finger lifted or gesture cancelled: reset visuals
-      pressed.value = 0;
-      scale.value = withTiming(1, {
-        duration: 140,
-        easing: Easing.out(Easing.ease),
-      });
-
-      if (state === GestureState.END) {
-        console.log('🟢 BusinessCard - Pressed business ID:', business.id);
-        onPress(business.id);
-      }
-    }
-  };
-
   // ✅ Handle heart press - use custom action if provided, otherwise default
   const handleFavoritePress = () => {
     if (customHeartAction) {
@@ -87,7 +51,26 @@ const BusinessCard = memo(({ business, onPress, customHeartAction }: BusinessCar
   };
 
   return (
-    <TapGestureHandler onHandlerStateChange={handleStateChange}>
+    <Pressable
+      onPress={() => {
+        console.log('🟢 BusinessCard - Pressed business ID:', business.id);
+        onPress(business.id);
+      }}
+      onPressIn={() => {
+        pressed.value = 1;
+        scale.value = withTiming(0.98, {
+          duration: 90,
+          easing: Easing.out(Easing.ease),
+        });
+      }}
+      onPressOut={() => {
+        pressed.value = 0;
+        scale.value = withTiming(1, {
+          duration: 140,
+          easing: Easing.out(Easing.ease),
+        });
+      }}
+    >
       <Animated.View style={[styles.card, animatedStyle]}>
         <Image
           source={{ uri: business.imageUrl }}
@@ -127,7 +110,7 @@ const BusinessCard = memo(({ business, onPress, customHeartAction }: BusinessCar
           </View>
         </View>
       </Animated.View>
-    </TapGestureHandler>
+    </Pressable>
   );
 });
 

--- a/src/hooks/queries/useBusinessDetailsQuery.ts
+++ b/src/hooks/queries/useBusinessDetailsQuery.ts
@@ -11,7 +11,8 @@ export const useBusinessDetailsQuery = (id: string | undefined) => {
     queryFn: () =>
       protectedAction(() => businessService.getBusinessById(id || ''), {
         actionName: 'Loading business details',
-        retry: true,
+        retry: false,
+        showAlert: false,
       }) as Promise<Awaited<ReturnType<typeof businessService.getBusinessById>>>,
   });
 };

--- a/src/hooks/queries/useBusinessReviewsQuery.ts
+++ b/src/hooks/queries/useBusinessReviewsQuery.ts
@@ -13,7 +13,8 @@ export const useBusinessReviewsQuery = (businessId: string | undefined) => {
     queryFn: () =>
       protectedAction(() => reviewService.getReviewsForBusiness(businessId || ''), {
         actionName: 'Loading business reviews',
-        retry: true,
+        retry: false,
+        showAlert: false,
       }) as Promise<Review[]>,
   });
 };

--- a/src/hooks/queries/useBusinessSearchQuery.ts
+++ b/src/hooks/queries/useBusinessSearchQuery.ts
@@ -40,7 +40,7 @@ export const useBusinessSearchQuery = (query: string, categories: string[] = [])
       protectedAction(
         () =>
           businessService.searchBusinessesWithQuery(trimmed, lat!, lng!, 5000, categories, false),
-        { actionName: 'Searching businesses', retry: true },
+        { actionName: 'Searching places', retry: false, showAlert: false },
       ) as Promise<Business[]>,
     staleTime: 60 * 1000,
   });

--- a/src/hooks/queries/useNearbyBusinessesQuery.ts
+++ b/src/hooks/queries/useNearbyBusinessesQuery.ts
@@ -27,7 +27,7 @@ export const useNearbyBusinessesQuery = () => {
             [],
             false,
           ),
-        { actionName: 'Loading nearby businesses', retry: true },
+        { actionName: 'Loading nearby places', retry: true },
       ) as Promise<Awaited<ReturnType<typeof businessService.getNearbyBusinesses>>>,
     staleTime: 5 * 60 * 1000,
   });
@@ -59,7 +59,7 @@ export const useRefreshNearbyBusinesses = () => {
           [],
           true, // forceRefresh: bypass AsyncStorage cache
         ),
-      { actionName: 'Refreshing nearby businesses', retry: true },
+      { actionName: 'Refreshing nearby places', retry: true },
     )) as Awaited<ReturnType<typeof businessService.getNearbyBusinesses>>;
 
     queryClient.setQueryData(queryKey, data);
@@ -113,8 +113,7 @@ export const useInfiniteNearbyBusinessesQuery = () => {
             forceRefresh: false,
           }),
         {
-          actionName:
-            page === 1 ? 'Loading nearby businesses (infinite)' : 'Loading more nearby businesses',
+          actionName: page === 1 ? 'Loading nearby places' : 'Loading more nearby places',
           retry: true,
         },
       )) as Awaited<ReturnType<typeof businessService.getNearbyBusinessesPage>>;

--- a/src/hooks/queries/useUserReviewsQuery.ts
+++ b/src/hooks/queries/useUserReviewsQuery.ts
@@ -14,8 +14,9 @@ export const useUserReviewsQuery = () => {
     queryKey: reviewQueryKeys.user(user?.uid ?? ''),
     queryFn: () =>
       protectedAction(() => reviewService.getUserReviews(user!.uid), {
-        actionName: 'Loading user reviews',
-        retry: true,
+        actionName: 'Loading your reviews',
+        retry: false,
+        showAlert: false,
       }) as Promise<Review[]>,
   });
 };

--- a/src/hooks/useProtectedAction.ts
+++ b/src/hooks/useProtectedAction.ts
@@ -35,19 +35,18 @@ export const useProtectedAction = () => {
 
       if (!connected) {
         if (showAlert) {
-          Alert.alert(
-            'No Internet Connection',
-            `${actionName} requires an internet connection. Please check your connection and try again.`,
-            retry
-              ? [
-                  { text: 'Cancel', style: 'cancel' },
-                  {
-                    text: 'Retry',
-                    onPress: () => protectedAction(action, options),
-                  },
-                ]
-              : [{ text: 'OK' }],
-          );
+          const message = `${actionName} requires an internet connection.`;
+          if (retry) {
+            Alert.alert('No Internet Connection', message, [
+              { text: 'Cancel', style: 'cancel' },
+              {
+                text: 'Retry',
+                onPress: () => protectedAction(action, options),
+              },
+            ]);
+          } else {
+            Alert.alert('No Internet Connection', message, [{ text: 'OK' }]);
+          }
         }
         return false;
       }

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -14,6 +14,10 @@ import { NotificationData } from '@/src/services/notificationService';
 import { OfflineBanner } from '@/src/components/OfflineBanner';
 import { AppErrorBoundary } from '@/src/components/AppErrorBoundary';
 import { crashReporter } from '@/src/services/crashReporter';
+import { useInternetConnectivity } from '@/src/hooks/useInternetConnectivity';
+import { favoriteService } from '@/src/services/favoriteService';
+import { offlineQueueService } from '@/src/services/offlineQueueService';
+import { reviewService } from '@/src/services/reviewService';
 
 import TabNavigator from './TabNavigator';
 import BusinessDetailsScreen from '../screens/business/BusinessDetailsScreen';
@@ -57,6 +61,118 @@ const Stack = createNativeStackNavigator();
 function AuthNavigator() {
   const { user, loading } = useAuthContext(); // ← USE CONTEXT INSTEAD
   const navigationRef = useNavigationContainerRef();
+  const { isConnected } = useInternetConnectivity();
+
+  // Flush any queued offline favorite toggles and review/helpful mutations
+  // once we have both a user and a confirmed network connection.
+  useEffect(() => {
+    const flushQueues = async () => {
+      if (!user || !isConnected) return;
+
+      // 1) Favorites queue (legacy key)
+      try {
+        const raw = await AsyncStorage.getItem('favoritesOfflineQueue_v1');
+        if (raw) {
+          const queue: { businessId: string; isCurrentlyFavorite: boolean }[] = JSON.parse(raw);
+          if (Array.isArray(queue) && queue.length > 0) {
+            for (const item of queue) {
+              try {
+                await favoriteService.toggleFavorite(
+                  user.uid,
+                  item.businessId,
+                  item.isCurrentlyFavorite,
+                );
+              } catch (error) {
+                console.warn('⚠️ Failed to replay offline favorite toggle:', {
+                  businessId: item.businessId,
+                  isCurrentlyFavorite: item.isCurrentlyFavorite,
+                  error,
+                });
+              }
+            }
+          }
+
+          await AsyncStorage.removeItem('favoritesOfflineQueue_v1');
+        }
+      } catch (error) {
+        console.error('Failed to flush offline favorites queue:', error);
+      }
+
+      // 2) Generic offline mutation queue (reviews + helpful votes)
+      try {
+        const allMutations = await offlineQueueService.getAll();
+        if (!allMutations.length) return;
+
+        // Only attempt to replay mutations that belong to the currently
+        // authenticated user. This avoids leaking actions across accounts
+        // if someone signs out/in while offline.
+        const mutations = allMutations.filter((m) => {
+          if (m.type === 'review:add') return m.payload.userId === user.uid;
+          if (m.type === 'review:delete') return true; // review doc itself encodes user
+          if (m.type === 'review:helpful') return m.taggedBy === user.uid;
+          return false;
+        });
+
+        const remaining: typeof allMutations = [];
+
+        for (const m of mutations) {
+          try {
+            if (m.type === 'review:add') {
+              // Skip if a review already exists for this user+business
+              const existing = await reviewService.getUserReviewForBusiness(
+                m.payload.userId,
+                m.payload.businessId,
+              );
+              if (!existing) {
+                await reviewService.addReview({
+                  businessId: m.payload.businessId,
+                  userId: m.payload.userId,
+                  userName: m.payload.userName,
+                  userAvatar: m.payload.userAvatar,
+                  rating: m.payload.rating,
+                  text: m.payload.text,
+                  images: m.payload.images,
+                  helpful: 0,
+                } as any);
+              }
+            } else if (m.type === 'review:delete') {
+              await reviewService.deleteReview(m.reviewId);
+            } else if (m.type === 'review:helpful') {
+              if (m.delta === 1) {
+                await reviewService.addHelpfulVote({
+                  reviewId: m.reviewId,
+                  reviewOwnerId: m.reviewOwnerId,
+                  taggedBy: m.taggedBy,
+                  businessId: m.businessId,
+                });
+                await reviewService.updateReviewHelpfulCount(m.reviewId, 1);
+              } else {
+                await reviewService.removeHelpfulVote(m.reviewId, m.taggedBy);
+                await reviewService.updateReviewHelpfulCount(m.reviewId, -1);
+              }
+            }
+          } catch (error) {
+            console.warn('⚠️ Failed to replay offline mutation, keeping in queue:', {
+              mutationId: m.id,
+              type: m.type,
+              error,
+            });
+            remaining.push(m);
+          }
+        }
+
+        // Keep any unprocessed mutations (including those for other users)
+        // so they can be retried on a future session.
+        await offlineQueueService.replaceAll(
+          remaining.concat(allMutations.filter((m) => !mutations.includes(m))),
+        );
+      } catch (error) {
+        console.error('Failed to flush offline mutation queue:', error);
+      }
+    };
+
+    flushQueues();
+  }, [user?.uid, isConnected]);
 
   // Handle notification press - navigate to business details with review highlight
   const handleNotificationPress = (data: NotificationData) => {

--- a/src/screens/business/AddReviewScreen.tsx
+++ b/src/screens/business/AddReviewScreen.tsx
@@ -29,6 +29,7 @@ import { reviewQueryKeys } from '@/src/services/reviewQueryKeys';
 import { businessQueryKeys } from '@/src/services/businessService';
 import { z } from 'zod';
 import { rateLimiter } from '@/src/utils/rateLimiter';
+import { useInternetConnectivity } from '@/src/hooks/useInternetConnectivity';
 
 const reviewSchema = z.object({
   rating: z
@@ -42,6 +43,7 @@ export default function AddReviewScreen() {
   const route = useRoute();
   const navigation = useNavigation();
   const queryClient = useQueryClient();
+  const { isConnected } = useInternetConnectivity();
   const {
     id,
     review: existingReview,
@@ -510,6 +512,16 @@ export default function AddReviewScreen() {
             </View>
           </View>
 
+          {!isConnected && (
+            <View style={styles.offlineBanner}>
+              <Text style={styles.offlineBannerTitle}>You are offline</Text>
+              <Text style={styles.offlineBannerText}>
+                Your review will be saved locally and synced automatically when your connection is
+                restored.
+              </Text>
+            </View>
+          )}
+
           <View style={styles.ratingSection}>
             <Text style={styles.sectionTitle}>How was your experience?</Text>
             <View style={styles.ratingContainer}>
@@ -722,6 +734,24 @@ const styles = StyleSheet.create({
   sectionTitle: { fontSize: 17, fontWeight: '600', color: '#333', marginBottom: 16 },
   ratingContainer: { alignItems: 'center' },
   ratingText: { fontSize: 15, color: '#666', marginTop: 12 },
+  offlineBanner: {
+    backgroundColor: '#FEF3C7',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: '#FBBF24',
+  },
+  offlineBannerTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#92400E',
+    marginBottom: 2,
+  },
+  offlineBannerText: {
+    fontSize: 12,
+    color: '#92400E',
+  },
   photoSection: {
     backgroundColor: '#FFF',
     padding: 16,

--- a/src/services/offlineQueueService.ts
+++ b/src/services/offlineQueueService.ts
@@ -1,0 +1,98 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// Simple versioned key so we can change the schema later without conflicts.
+const STORAGE_KEY = 'offlineMutations_v1';
+
+// Guardrail to prevent unbounded growth if the app stays offline
+// for a long time or something constantly fails to sync.
+const MAX_MUTATIONS = 50;
+
+export type OfflineMutation =
+  | {
+      type: 'review:add';
+      id: string;
+      payload: {
+        businessId: string;
+        userId: string;
+        userName: string;
+        userAvatar: string;
+        rating: number;
+        text: string;
+        images: string[];
+      };
+      createdAt: string;
+    }
+  | {
+      type: 'review:delete';
+      id: string;
+      reviewId: string;
+      businessId: string;
+      createdAt: string;
+    }
+  | {
+      type: 'review:helpful';
+      id: string;
+      reviewId: string;
+      reviewOwnerId: string;
+      taggedBy: string;
+      businessId: string;
+      delta: 1 | -1;
+      createdAt: string;
+    };
+
+interface StoredState {
+  mutations: OfflineMutation[];
+}
+
+const loadState = async (): Promise<StoredState> => {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return { mutations: [] };
+    const parsed = JSON.parse(raw) as StoredState;
+    if (!parsed || !Array.isArray(parsed.mutations)) {
+      return { mutations: [] };
+    }
+
+    // Drop obviously malformed entries and hard-cap the queue size
+    const trimmed = parsed.mutations.slice(-MAX_MUTATIONS).filter(Boolean);
+    return { mutations: trimmed };
+  } catch (error) {
+    console.warn('⚠️ offlineQueueService: failed to load state', error);
+    return { mutations: [] };
+  }
+};
+
+const saveState = async (state: StoredState): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn('⚠️ offlineQueueService: failed to save state', error);
+  }
+};
+
+export const offlineQueueService = {
+  async enqueue(mutation: OfflineMutation): Promise<void> {
+    const state = await loadState();
+    state.mutations.push(mutation);
+
+    // Enforce a simple FIFO cap so the queue cannot grow without bound.
+    if (state.mutations.length > MAX_MUTATIONS) {
+      state.mutations.splice(0, state.mutations.length - MAX_MUTATIONS);
+    }
+
+    await saveState(state);
+  },
+
+  async getAll(): Promise<OfflineMutation[]> {
+    const state = await loadState();
+    return state.mutations;
+  },
+
+  async clear(): Promise<void> {
+    await saveState({ mutations: [] });
+  },
+
+  async replaceAll(mutations: OfflineMutation[]): Promise<void> {
+    await saveState({ mutations });
+  },
+};


### PR DESCRIPTION
 - Introduce AsyncStorage-backed offlineQueueService for review add/delete and helpful vote mutations
 - Wire useAppStore.addReview and deleteReview to enqueue offline mutations with optimistic local updates
 - Queue favorites and helpful votes on network failure instead of blocking with generic alerts
 - Render offline-created reviews with a "Pending sync" badge in ReviewCard for transparent offline state
 - Add inline offline banners to BusinessDetailsScreen and AddReviewScreen explaining queued behavior
 - Auto-refresh business details and reviews when connectivity is restored while BusinessDetails is visible
 - Standardize useProtectedAction offline alerts (consistent message, Retry only for primary nearby loads)
 - Suppress noisy alerts for secondary queries (details, reviews, user reviews, search) in favor of banners
 - Fix ReviewCard avatar helpers (isDefaultAvatarUrl/hasCustomAvatar) to avoid runtime errors offline
 - Add Jest coverage for offlineQueueService, including MAX_MUTATIONS capping and replace/clear behavior