### PR TITLE
docs: add development and contributing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+## Branch naming
+
+Create branches from `main` using:
+
+- `feat/...` for new features
+- `fix/...` for bug fixes
+- `docs/...` for documentation changes
+- `test/...` for test-only changes
+- `chore/...` for maintenance
+
+Examples:
+
+- `feat/offline-mutation-queue`
+- `fix/review-card-avatar-fallback`
+- `docs/add-development-guide`
+
+## Commit messages
+
+We follow a Conventional Commit style:
+
+```text
+<type>(optional-scope): short, imperative subject
+
+Optional longer body describing what and why, wrapped at ~72 chars.
+```
+
+Common types:
+
+- `feat` – new feature
+- `fix` – bug fix
+- `docs` – docs only
+- `test` – tests only
+- `chore` – tooling/infra
+- `refactor` – code change without behaviour change
+
+Examples:
+
+```text
+docs: add development and contributing guides
+
+- Add docs/DEVELOPMENT.md
+- Add CONTRIBUTING.md
+- Link both from README
+```
+
+```text
+fix(reviews): handle missing avatar urls safely
+```
+
+Multi-line commits are preferred for anything non-trivial so the body can list bullets.
+
+## Before opening a PR
+
+- Make sure tests pass:
+  ```bash
+  npm test
+  ```
+- Run lint and format:
+  ```bash
+  npm run lint
+  npm run format
+  ```
+- Update docs if you changed public behaviour, env vars, or APIs.
+
+## PR checklist (informal)
+
+- [ ] Good, descriptive title (same style as a commit subject)
+- [ ] Summary of the change and why
+- [ ] Notes on how you tested it
+- [ ] Screenshots or videos for any visible UI change
+
+Keeping to these conventions makes the history easy to read and review over time.

--- a/README.md
+++ b/README.md
@@ -414,7 +414,16 @@ To run these flows, install Maestro CLI and follow the instructions in `TESTING.
 
 ---
 
-## 9. Summary
+## 9. Development & Contribution Docs
+
+- Day-to-day dev workflow, test commands, and offline-first notes: see `docs/DEVELOPMENT.md`.
+- Branch naming and Conventional Commit structure: see `CONTRIBUTING.md`.
+
+These two docs are the source of truth for how to work on this project and how to structure history.
+
+---
+
+## 10. Summary
 
 This project’s architecture separates concerns into:
 
@@ -425,13 +434,13 @@ This project’s architecture separates concerns into:
 - **Context** for shared app state (auth, role, profile).
 - **Utils** for pure helpers (like mapping external API data to domain models).
 
-Testing covers core services, hooks, and screens via Jest, with a minimal Maestro-based e2e flow to validate the real app on a device.
+Testing covers core services, hooks, and screens via Jest, with a minimal Maestro-based e2e flow to validate the real app on a device. In addition to the heavier integration suites, there are several small, fast tests for utilities and UI pieces (e.g. `rateLimiter`, `logger`, `OfflineBanner`, and simple form components) to push coverage without adding flakiness.
 
 This structure and documentation are designed to make the app easier to understand, extend, and evaluate from an architectural and production-readiness perspective.
 
 ---
 
-## 10. Code Quality & Tooling
+## 11. Code Quality & Tooling
 
 - **Linting:** `npm run lint` (Expo lint) and `npm run lint:eslint` (raw ESLint) enforce code style and catch common issues across JS/TS/React Native files.
 - **Formatting:** `npm run format` and `npm run format:check` use Prettier to keep formatting consistent across the codebase.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,103 @@
+# Development Guide
+
+This guide covers how to set up, run, test, and extend the Local Guides app in a way that matches the rest of the codebase.
+
+## Prerequisites
+
+- Node.js 18+ and npm (LTS recommended)
+- Expo tooling (via `npx expo` or global `expo` CLI)
+- iOS Simulator (Xcode) and/or Android emulator or physical device
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and fill in the values you have (Firebase, Geoapify, etc.).
+3. Start the dev server:
+   ```bash
+   npm run expo:start
+   ```
+
+## Running the app
+
+- iOS simulator:
+  ```bash
+  npm run expo:ios
+  ```
+- Android emulator/device:
+  ```bash
+  npm run expo:android
+  ```
+
+## Testing
+
+See `TESTING.md` for full details, but the common commands are:
+
+- Run all tests:
+  ```bash
+  npm test
+  ```
+- Run a single test file:
+  ```bash
+  TMPDIR="$PWD/.tmp" npx jest --runInBand __tests__/utils/logger.test.ts
+  ```
+- Jest watch mode:
+  ```bash
+  npm run test:watch
+  ```
+
+The test tree mirrors `src/`:
+
+- `__tests__/services` – service and offline-queue tests
+- `__tests__/hooks` – custom hooks
+- `__tests__/components` – small UI pieces
+- `__tests__/screens` – light integration tests around navigation/screens
+
+Recent smaller, fast suites include:
+
+- `__tests__/utils/rateLimiter.test.ts`
+- `__tests__/utils/logger.test.ts`
+- `__tests__/components/OfflineBanner.test.tsx`
+- `__tests__/components/simpleComponents.test.tsx`
+
+When adding new tests, favor:
+
+- Pure functions and small components over heavy navigation stacks
+- Fast, deterministic tests without network or timers where possible
+
+## Code quality
+
+- Lint:
+  ```bash
+  npm run lint
+  ```
+- Format:
+  ```bash
+  npm run format
+  ```
+- Type-check (if needed):
+  ```bash
+  npx tsc --noEmit
+  ```
+
+## Branches and commits
+
+- Create a feature branch from `main` using a short, descriptive name, e.g. `feat/offline-queue`, `docs/add-dev-guide`.
+- Use Conventional Commit messages. See `CONTRIBUTING.md` for full rules, but a typical commit looks like:
+
+  ```text
+  docs: add development guide and contributing rules
+
+  - Describe the main change
+  - Mention any tests or docs you touched
+  ```
+
+## Offline-first behaviour (quick reference)
+
+- Favorites, reviews, and helpful votes queue locally when offline.
+- `BusinessDetailsScreen` and `AddReviewScreen` show inline offline banners.
+- Queued actions sync automatically when connectivity returns.
+
+If you change any of this behaviour, please update both this file and the README offline section.


### PR DESCRIPTION
- Add docs/DEVELOPMENT.md with setup, testing, and offline-first notes
- Add CONTRIBUTING.md with branch and commit conventions
- Link both docs from README and mention new fast test suite